### PR TITLE
Fix EOL Errors

### DIFF
--- a/Grocery.App/Grocery.App.csproj
+++ b/Grocery.App/Grocery.App.csproj
@@ -36,6 +36,10 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+
+		<!-- NETSDK1202: The workload 'net8.0-ios' is out of support and will not receive security updates in the future. -->
+		<CheckEolWorkloads>false</CheckEolWorkloads>
+
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
**Description:**

Fix EOL Errors:
- NETSDK1202: The workload 'net8.0-ios' is out of support and will not receive security updates in the future.
- NETSDK1202: The workload 'net8.0-maccatalyst' is out of support and will not receive security updates in the future.

**Related issue or usecase:**
https://github.com/Miniontoby/OOSDD_GroceryApp_Studenten/actions/runs/18523991998

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
